### PR TITLE
fix: Prevent E5560 error by scheduling notify calls in login callbacks

### DIFF
--- a/lua/neoment/init.lua
+++ b/lua/neoment/init.lua
@@ -54,11 +54,15 @@ local function login()
 
 	matrix.login(username, password, function(data)
 		if error.is_error(data) then
-			vim.notify("Error logging in: " .. data.error.error, vim.log.levels.ERROR)
+    		vim.schedule(function()
+				vim.notify("Error logging in: " .. data.error.error, vim.log.levels.ERROR)
+			end)
 			return
 		end
 
-		vim.notify("Login successful as " .. matrix.client.user_id, vim.log.levels.INFO)
+    	vim.schedule(function()
+			vim.notify("Login successful as " .. matrix.client.user_id, vim.log.levels.INFO)
+		end)
 
 		-- Save the session if configured
 		if vim.g.neoment.save_session then


### PR DESCRIPTION
## Problem
When using the login functionality, the plugin throws error E5560: `nvim_echo must not be called in a fast event context`. This occurs because `vim.notify` is being called directly within callback functions that run in a fast event context where UI operations are not permitted.

## Solution
Wrapped all `vim.notify` calls in the `matrix.login` callback function with `vim.schedule()` to ensure they run in the main Neovim event loop where UI functions are allowed.

## Testing
Manually tested the login flow with both:
- Successful authentication: notification displays properly without errors
- Failed authentication: error message displays properly without the E5560 error