### PR TITLE
restore windows option only when BufWinLeave

### DIFF
--- a/after/ftplugin/neoment_room.lua
+++ b/after/ftplugin/neoment_room.lua
@@ -21,7 +21,7 @@ end
 local old_number = vim.wo.number
 local old_relativenumber = vim.wo.relativenumber
 local old_cursorline = vim.wo.cursorline
-vim.api.nvim_create_autocmd("BufLeave", {
+vim.api.nvim_create_autocmd("BufWinLeave", {
 	buffer = buffer_id,
 	callback = function()
 		vim.wo.number = old_number

--- a/after/ftplugin/neoment_rooms.lua
+++ b/after/ftplugin/neoment_rooms.lua
@@ -8,7 +8,7 @@ vim.api.nvim_set_option_value("modified", false, { buf = 0 })
 local old_number = vim.wo.number
 local old_relativenumber = vim.wo.relativenumber
 local old_cursorline = vim.wo.cursorline
-vim.api.nvim_create_autocmd("BufLeave", {
+vim.api.nvim_create_autocmd("BufWinLeave", {
 	buffer = buffer_id,
 	callback = function()
 		vim.wo.number = old_number
@@ -16,7 +16,7 @@ vim.api.nvim_create_autocmd("BufLeave", {
 		vim.wo.cursorline = old_cursorline
 	end,
 })
-vim.api.nvim_create_autocmd("BufEnter", {
+vim.api.nvim_create_autocmd("BufWinEnter", {
 	buffer = buffer_id,
 	callback = function()
 		vim.wo.number = false


### PR DESCRIPTION
before this PR, when switch from rooms window to room window, the number of rooms window is enabled.

so the number option should be restroed only when rooms buffer is left from rooms windows.