### PR TITLE
feat: add picker source

### DIFF
--- a/lua/neoment/icon.lua
+++ b/lua/neoment/icon.lua
@@ -12,6 +12,9 @@ M.space = "󰴖"
 
 M.room = "󰮧"
 
+-- ≡ U+2261（thread / list）
+M.thread = '≡'
+
 M.low_priority = "󰘄"
 
 M.reply = "↳"

--- a/lua/picker/sources/neoment_chats.lua
+++ b/lua/picker/sources/neoment_chats.lua
@@ -2,10 +2,10 @@
 -- require picker.nvim
 
 local M = {}
-
 M.get = function()
 	local chatbufs = vim.tbl_filter(function(buf)
 		return vim.startswith(vim.api.nvim_buf_get_name(buf), "neoment://room/!")
+			or vim.startswith(vim.api.nvim_buf_get_name(buf), "neoment://thread/")
 	end, vim.api.nvim_list_bufs())
 
 	local icons = require("neoment.icon")
@@ -14,8 +14,14 @@ M.get = function()
 
 	for _, buf in ipairs(chatbufs) do
 		local room_name = require("neoment.matrix").get_room_name(vim.b[buf].room_id)
+		local display
+		if vim.b[buf].thread_root_id then
+			display = string.format("%s %s > Thread", icons.thread, room_name)
+		else
+			display = string.format("%s %s", icons.room, room_name)
+		end
 		table.insert(items, {
-			str = icons.room .. " " .. room_name,
+			str = display,
 			value = {
 				buf = buf,
 			},


### PR DESCRIPTION
1. use [picker.nvim](https://github.com/wsdjeg/picker.nvim) as default vim.ui.select

```lua
        vim.ui.select = function(items, opt, callback)
            local source = {}
            opt = opt or {}
            if opt.prompt then
                source.name = opt.prompt
            else
                source.name = 'Select one of:'
            end

            source.get = function()
                local entrys = {}
                for idx, item in ipairs(items) do
                    local entry = {
                        value = item,
                        idx = idx, -- this also can be nil
                    }

                    if opt.format_item then
                        entry.str = opt.format_item(item)
                    else
                        entry.str = item
                    end
                    table.insert(entrys, entry)
                end
                return entrys
            end

            source.default_action = function(entry)
                if callback then
                    callback(entry.value, entry.idx)
                end
            end

            require('picker.windows').open(source, {
                buf = vim.api.nvim_get_current_buf(),
            })
        end
```

`:Neoment rooms`

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/9392174b-7b41-4699-9ea5-efbf86819cfd" />


2. chat room sources for picker.nvim, `:Picker neoment_chat`

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/0fdaa68d-415b-4133-8eb3-bbdc29405f22" />
