### PR TITLE
fix: restore global windows opts

### DIFF
--- a/after/ftplugin/neoment_room.lua
+++ b/after/ftplugin/neoment_room.lua
@@ -3,6 +3,7 @@ if vim.b.did_ftplugin then
 end
 vim.b.did_ftplugin = true
 local buffer_id = vim.api.nvim_get_current_buf()
+local window_id = vim.api.nvim_get_current_win()
 local room_id = vim.b.room_id
 local util = require("neoment.util")
 
@@ -21,26 +22,26 @@ end
 vim.api.nvim_create_autocmd("BufWinLeave", {
 	buffer = buffer_id,
 	callback = function()
-		vim.wo.number = vim.go.number
-		vim.wo.relativenumber = vim.go.relativenumber
-		vim.wo.cursorline = vim.go.cursorline
+		vim.wo[window_id].number = vim.go.number
+		vim.wo[window_id].relativenumber = vim.go.relativenumber
+		vim.wo[window_id].cursorline = vim.go.cursorline
 	end,
 })
 vim.api.nvim_create_autocmd({ "BufEnter", "BufWinEnter" }, {
 	buffer = buffer_id,
 	callback = function()
-		vim.wo.conceallevel = 2
-		vim.wo.concealcursor = "n"
-		vim.wo.wrap = true
-		vim.wo.foldmethod = "manual"
-		vim.wo.signcolumn = "no"
-		vim.wo.number = false
-		vim.wo.relativenumber = false
-		vim.wo.conceallevel = 2
-		vim.wo.cursorline = true
-		vim.wo.breakindent = true
-		vim.wo.breakindentopt = "shift:31,sbr"
-		vim.wo.showbreak = string.rep(" ", 29) .. "│ "
+		vim.wo[window_id].conceallevel = 2
+		vim.wo[window_id].concealcursor = "n"
+		vim.wo[window_id].wrap = true
+		vim.wo[window_id].foldmethod = "manual"
+		vim.wo[window_id].signcolumn = "no"
+		vim.wo[window_id].number = false
+		vim.wo[window_id].relativenumber = false
+		vim.wo[window_id].conceallevel = 2
+		vim.wo[window_id].cursorline = true
+		vim.wo[window_id].breakindent = true
+		vim.wo[window_id].breakindentopt = "shift:31,sbr"
+		vim.wo[window_id].showbreak = string.rep(" ", 29) .. "│ "
 		local winbar = require("neoment.matrix").get_room_name(room_id)
 		local topic = require("neoment.matrix").get_room_topic(room_id)
 		local thread_root_id = vim.b[buffer_id].thread_root_id
@@ -54,8 +55,8 @@ vim.api.nvim_create_autocmd({ "BufEnter", "BufWinEnter" }, {
 		require("neoment.room").mark_read(buffer_id)
 	end,
 })
-vim.wo.number = false
-vim.wo.relativenumber = false
+vim.wo[window_id].number = false
+vim.wo[window_id].relativenumber = false
 
 -- avoid `:e` command clear buffer context and syntax highlight.
 -- BufReadPre, BufRead and BufReadPost will not be triggered as the file does not exist.

--- a/after/ftplugin/neoment_rooms.lua
+++ b/after/ftplugin/neoment_rooms.lua
@@ -3,6 +3,7 @@ if vim.b.did_ftplugin then
 end
 vim.b.did_ftplugin = true
 local buffer_id = vim.api.nvim_get_current_buf()
+local windows_id = vim.api.nvim_get_current_win()
 local util = require("neoment.util")
 
 vim.bo.buftype = "nofile"
@@ -11,18 +12,30 @@ vim.bo.swapfile = false
 vim.api.nvim_create_autocmd("BufWinLeave", {
 	buffer = buffer_id,
 	callback = function()
-		vim.wo.number = vim.go.number
-		vim.wo.relativenumber = vim.go.relativenumber
-		vim.wo.cursorline = vim.go.cursorline
+		vim.api.nvim_set_option_value(
+			"number",
+			vim.api.nvim_get_option_value("number", { scope = "global" }),
+			{ win = windows_id }
+		)
+		vim.api.nvim_set_option_value(
+			"relativenumber",
+			vim.api.nvim_get_option_value("relativenumber", { scope = "global" }),
+			{ win = windows_id }
+		)
+		vim.api.nvim_set_option_value(
+			"cursorline",
+			vim.api.nvim_get_option_value("cursorline", { scope = "global" }),
+			{ win = windows_id }
+		)
 	end,
 })
 vim.api.nvim_create_autocmd("BufWinEnter", {
 	buffer = buffer_id,
 	callback = function()
-		vim.wo.number = false
-		vim.wo.relativenumber = false
-		vim.wo.cursorline = true
-		vim.wo.winfixwidth = true
+		vim.api.nvim_set_option_value("number", false, { win = windows_id })
+		vim.api.nvim_set_option_value("relativenumber", false, { win = windows_id })
+		vim.api.nvim_set_option_value("cursorline", true, { win = windows_id })
+		vim.api.nvim_set_option_value("winfixwidth", true, { win = windows_id })
 	end,
 })
 

--- a/after/ftplugin/neoment_space.lua
+++ b/after/ftplugin/neoment_space.lua
@@ -3,6 +3,7 @@ if vim.b.did_ftplugin then
 end
 vim.b.did_ftplugin = true
 local buffer_id = vim.api.nvim_get_current_buf()
+local windows_id = vim.api.nvim_get_current_win()
 local util = require("neoment.util")
 
 -- Destroy completely the buffer when closing
@@ -26,9 +27,9 @@ vim.api.nvim_create_autocmd("BufReadCmd", {
 vim.api.nvim_create_autocmd("BufWinLeave", {
 	buffer = buffer_id,
 	callback = function()
-		vim.wo.number = vim.go.number
-		vim.wo.relativenumber = vim.go.relativenumber
-		vim.wo.cursorline = vim.go.cursorline
+		vim.wo[windows_id].number = vim.go.number
+		vim.wo[windows_id].relativenumber = vim.go.relativenumber
+		vim.wo[windows_id].cursorline = vim.go.cursorline
 	end,
 })
 


### PR DESCRIPTION
plugin buffer should restore global windows option, just make sure same as  normal splits in neovim. old wo.number maybe changed by other plugin.