### PR TITLE
feat(rooms): add configurable last message display in room list

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ vim.g.neoment = {
 		end,
 	},
 	
+	-- Settings for the room list
+	rooms = {
+		-- How to display the last message. The last message is shown below the room name
+		-- Options:
+		-- "no" - do not show the last message
+		-- "message" - show the last message content
+		-- "sender_message" - show the sender and last message content, each one on its own line
+		-- "sender_message_inline" - show the sender and last message content on the same line.
+		display_last_message = "message",
+	}
+	
 	-- Icon configuration (all optional)
 	icon = {
 		invite = "",              -- Icon for room invites

--- a/lua/neoment/config.lua
+++ b/lua/neoment/config.lua
@@ -6,6 +6,7 @@
 --- @field icon? neoment.config.Icon Icon configuration
 --- @field notifier fun(msg: string, level: vim.log.levels, opts?: table): nil Function to show notifications
 --- @field picker? neoment.config.Picker Picker configuration
+--- @field rooms? neoment.config.Rooms
 
 --- @alias neoment.config.PickerFunction fun(items: neoment.config.PickerRoom[], callback: fun(room: neoment.matrix.client.Room), options: neoment.config.PickerOptions): nil
 
@@ -44,11 +45,15 @@
 --- @field location? string Icon for location
 --- @field video? string Icon for video files
 
+--- @class neoment.config.Rooms
+--- @field display_last_message? neoment.config.DisplayLastMessage How to display the last message in the room list
+
 --- @class neoment.config.InternalConfig
 --- @field save_session boolean Whether to save and restore sessions
 --- @field icon neoment.config.InternalIcon Icon configuration
 --- @field notifier fun(msg: string, level: vim.log.levels, opts?: table): nil Function to show notifications
 --- @field picker neoment.config.InternalPicker Picker configuration
+--- @field rooms neoment.config.InternalRooms
 
 --- @class neoment.config.InternalPicker
 --- @field rooms neoment.config.PickerFunction Custom picker for rooms
@@ -77,6 +82,11 @@
 --- @field audio string Icon for audio files
 --- @field location string Icon for location
 --- @field video string Icon for video files
+
+--- @class neoment.config.InternalRooms
+--- @field display_last_message neoment.config.DisplayLastMessage How to display the last message in the room list
+
+--- @alias neoment.config.DisplayLastMessage "no"|"message"|"sender_message"|"sender_message_inline"
 
 local M = {}
 
@@ -128,6 +138,9 @@ local default = {
 	picker = {
 		rooms = default_room_picker,
 		open_rooms = default_room_picker,
+	},
+	rooms = {
+		display_last_message = "message",
 	},
 }
 

--- a/lua/neoment/storage.lua
+++ b/lua/neoment/storage.lua
@@ -102,11 +102,12 @@ function M.save_session()
 	}
 
 	for room_id, room in pairs(matrix.get_rooms()) do
+		local last_message = matrix.get_room_last_message(room_id)
 		-- Create a simplified version of the room for storage
 		local saved_room = vim.tbl_extend("force", room, {
 			events = {},
 			pending_events = {},
-			messages = {},
+			messages = last_message and { [last_message.id] = last_message } or {},
 			typing = {},
 		})
 		saved_room.prev_batch = nil


### PR DESCRIPTION
Add new `rooms.display_last_message` configuration option to control
how the last message is displayed in the room list. Supports four
modes:
- "no": do not show the last message
- "message": show only the message content
- "sender_message": show sender and message on separate lines
- "sender_message_inline": show sender and message on same line

Changes include:
- Add `rooms` config section with `display_last_message` option
- Update `get_room_last_message()` to skip state events
- Store last message for non-tracked rooms to improve performance
- Add virtual lines rendering for last message display
- Update session storage to preserve last message

Default behavior is "message" mode, showing the last message content
below each room name with a tree-style indicator.