### PR TITLE
feat: add desktop notifications for new messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ vim.g.neoment = {
 	notifier = function(msg, level, opts)
 		vim.notify(msg, level, opts)
 	end,
+	-- Custom desktop notifier function (optional)
+	-- Desktop notifications are shown for new messages in open rooms, excluding the currently focused room
+	-- Set to nil (or provide an empty function) to disable desktop notifications
+	-- By default, uses vim.fn.system to call:
+	-- - gdbus on Linux
+	-- - osascript on macOS
+	-- - PowerShell on Windows
+	desktop_notifier = function(title, content)
+		if jit.os == "Linux" or jit.os == "BSD" then
+			-- Using gdbus for Linux/BSD
+		elseif jit.os == "Windows" then
+			-- Using powershell for Windows
+		elseif jit.os == "OSX" then
+			-- Using osascript for macOS
+		end
+	end,
 	
 	-- Picker configuration (optional)
 	-- Customize the UI for room selection (default: vim.ui.select)

--- a/lua/neoment/config.lua
+++ b/lua/neoment/config.lua
@@ -5,6 +5,7 @@
 --- @field save_session? boolean Whether to save and restore sessions
 --- @field icon? neoment.config.Icon Icon configuration
 --- @field notifier fun(msg: string, level: vim.log.levels, opts?: table): nil Function to show notifications
+--- @field desktop_notifier? fun(title: string, content: string): nil Function to show desktop notifications
 --- @field picker? neoment.config.Picker Picker configuration
 --- @field rooms? neoment.config.Rooms
 
@@ -52,6 +53,7 @@
 --- @field save_session boolean Whether to save and restore sessions
 --- @field icon neoment.config.InternalIcon Icon configuration
 --- @field notifier fun(msg: string, level: vim.log.levels, opts?: table): nil Function to show notifications
+--- @field desktop_notifier? fun(title: string, content: string): nil Function to show desktop notifications
 --- @field picker neoment.config.InternalPicker Picker configuration
 --- @field rooms neoment.config.InternalRooms
 
@@ -135,6 +137,9 @@ local default = {
 		video = "",
 	},
 	notifier = vim.notify,
+	desktop_notifier = function(title, content)
+		require("neoment.notify").desktop(title, content)
+	end,
 	picker = {
 		rooms = default_room_picker,
 		open_rooms = default_room_picker,

--- a/lua/neoment/matrix/client.lua
+++ b/lua/neoment/matrix/client.lua
@@ -277,7 +277,8 @@ M.add_room_message = function(room_id, message)
 
 		-- Only notify for rooms that are not the current active buffer
 		local current_buf_room_id = vim.b.room_id
-		if room_id ~= current_buf_room_id and not message.is_state then
+		local user_id = require("neoment.matrix").get_user_id()
+		if room_id ~= current_buf_room_id and not message.is_state and message.sender ~= user_id then
 			require("neoment.notify").desktop_message(message.sender, message.content)
 		end
 	elseif not message.is_state then

--- a/lua/neoment/matrix/client.lua
+++ b/lua/neoment/matrix/client.lua
@@ -274,6 +274,12 @@ M.add_room_message = function(room_id, message)
 
 	if room.is_tracked then
 		room.messages[message.id] = message
+
+		-- Only notify for rooms that are not the current active buffer
+		local current_buf_room_id = vim.b.room_id
+		if room_id ~= current_buf_room_id and not message.is_state then
+			require("neoment.notify").desktop_message(message.sender, message.content)
+		end
 	elseif not message.is_state then
 		-- If the room is not tracked, only store the last message
 		local last_message = M.get_room_last_message(room_id)

--- a/lua/neoment/notify.lua
+++ b/lua/neoment/notify.lua
@@ -96,7 +96,14 @@ M.desktop = function(title, content)
 		vim.system({
 			"osascript",
 			"-e",
-			string.format('display notification %q with title "Neoment" subtitle %q', content, title),
+			[[
+          on run argv
+            display notification (item 1 of argv) with title "Neoment" subtitle (item 2 of argv)
+          end run
+         ]],
+			"--",
+			content,
+			title,
 		})
 	end
 end

--- a/lua/neoment/notify.lua
+++ b/lua/neoment/notify.lua
@@ -109,7 +109,10 @@ M.desktop = function(title, content)
 end
 
 M.desktop_message = function(sender, content)
-	M.desktop(require("neoment.matrix").get_display_name(sender), content)
+	local notifier = config.get().desktop_notifier
+	if notifier then
+		notifier(require("neoment.matrix").get_display_name(sender), content)
+	end
 end
 
 return M


### PR DESCRIPTION
Add desktop notification support across Linux, Windows, and macOS
platforms when messages arrive in open rooms. Notifications
display the sender's name and message content using platform-native
notification systems.

- Add desktop() and desktop_message() functions to notify module
- Integrate gdbus for Linux/BSD notifications
- Implement PowerShell-based notifications for Windows
- Use osascript for macOS notifications
- Trigger notifications in add_room_message() for open rooms
- Refactor storage to use get_stripped_room() helper function
- Exclude state events from triggering notifications