### PR TITLE
Fix: Incorrect gdbus command

### DIFF
--- a/lua/neoment/notify.lua
+++ b/lua/neoment/notify.lua
@@ -83,7 +83,7 @@ M.desktop = function(title, content)
 			content,
 			"[]",
 			string.format("{%s, %s}", '"urgency": <byte 1>', '"desktop-entry": <string "nvim">'),
-			"int32 -1",
+			"-1",
 		})
 	elseif jit.os == "Windows" then
 		vim.system({


### PR DESCRIPTION
Refactor the `gdbus` command used on Linux (and BSD) systems for notifications to ensure correct formatting. Closes #29.