### PR TITLE
feat(notify): add granular desktop notification controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ vim.g.neoment = {
 		vim.notify(msg, level, opts)
 	end,
 	
-	-- Desktop notifications are shown for new messages in open rooms, excluding the currently focused room
+	-- Desktop notifications can be configured per room type.
+	-- The buffer setting applies to currently open rooms (excluding the focused room),
+	-- while favorites, people, and rooms settings apply to all rooms of those types.
 	desktop_notifications = {
 		enabled = true,  -- Enable or disable desktop notifications (default: true)
 		

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Neoment is a Matrix protocol client implementation for Neovim that allows you to
 - Threads
 - Mark room as read/unread/favorite/low priority
 - Compose messages with markdown support
+- Desktop notifications for new messages
 
 ## Installation
 
@@ -101,22 +102,36 @@ vim.g.neoment = {
 	notifier = function(msg, level, opts)
 		vim.notify(msg, level, opts)
 	end,
-	-- Custom desktop notifier function (optional)
+	
 	-- Desktop notifications are shown for new messages in open rooms, excluding the currently focused room
-	-- Set to nil (or provide an empty function) to disable desktop notifications
-	-- By default, uses vim.fn.system to call:
-	-- - gdbus on Linux
-	-- - osascript on macOS
-	-- - PowerShell on Windows
-	desktop_notifier = function(title, content)
-		if jit.os == "Linux" or jit.os == "BSD" then
-			-- Using gdbus for Linux/BSD
-		elseif jit.os == "Windows" then
-			-- Using powershell for Windows
-		elseif jit.os == "OSX" then
-			-- Using osascript for macOS
-		end
-	end,
+	desktop_notifications = {
+		enabled = true,  -- Enable or disable desktop notifications (default: true)
+		
+		-- Custom desktop notifier handler (optional)
+		-- By default, uses vim.fn.system to call:
+		-- - gdbus on Linux
+		-- - osascript on macOS
+		-- - PowerShell on Windows
+		handler = function(title, content)
+			if jit.os == "Linux" or jit.os == "BSD" then
+				-- Using gdbus for Linux/BSD
+			elseif jit.os == "Windows" then
+				-- Using powershell for Windows
+			elseif jit.os == "OSX" then
+				-- Using osascript for macOS
+			end
+		end,
+		
+		-- Notification levels for different room types
+		-- Options: "all", "mentions", "none"
+		-- "all" - notify for all new messages
+		-- "mentions" - notify only for mentions/highlights
+		-- "none" - do not notify
+		buffer = "all", -- When buffer is set to "none", it'll inherit the room setting from its type
+		favorites = "all",
+		people = "all",
+		rooms = "mentions"
+	},
 	
 	-- Picker configuration (optional)
 	-- Customize the UI for room selection (default: vim.ui.select)

--- a/lua/neoment/config.lua
+++ b/lua/neoment/config.lua
@@ -107,7 +107,7 @@
 --- @field buffer neoment.config.DesktopNotificationLevel Notification level for buffer messages. When "none", it'll inherit from the other levels
 --- @field favorites neoment.config.DesktopNotificationLevel Notification level for favorite rooms
 --- @field people neoment.config.DesktopNotificationLevel Notification level for people rooms
---- @field rooms neoment.config.DesktopNotificationLevel Notification level for people rooms
+--- @field rooms neoment.config.DesktopNotificationLevel Notification level for non-favorite, non-direct rooms
 
 local M = {}
 

--- a/lua/neoment/config.lua
+++ b/lua/neoment/config.lua
@@ -55,7 +55,7 @@
 --- @field buffer? neoment.config.DesktopNotificationLevel Notification level for buffer messages. When "none", it'll inherit from the other levels
 --- @field favorites? neoment.config.DesktopNotificationLevel Notification level for favorite rooms
 --- @field people? neoment.config.DesktopNotificationLevel Notification level for people rooms
---- @field rooms? neoment.config.DesktopNotificationLevel Notification level for people rooms
+--- @field rooms? neoment.config.DesktopNotificationLevel Notification level for non-favorite, non-direct rooms
 
 --- @alias neoment.config.DesktopNotificationHandler fun(title: string, content: string): nil
 --- @alias neoment.config.DesktopNotificationLevel "all"|"mentions"|"none"

--- a/lua/neoment/config.lua
+++ b/lua/neoment/config.lua
@@ -5,7 +5,7 @@
 --- @field save_session? boolean Whether to save and restore sessions
 --- @field icon? neoment.config.Icon Icon configuration
 --- @field notifier fun(msg: string, level: vim.log.levels, opts?: table): nil Function to show notifications
---- @field desktop_notifier? fun(title: string, content: string): nil Function to show desktop notifications
+--- @field desktop_notifications? neoment.config.DesktopNotifications Configuration for desktop notifications
 --- @field picker? neoment.config.Picker Picker configuration
 --- @field rooms? neoment.config.Rooms
 
@@ -49,11 +49,22 @@
 --- @class neoment.config.Rooms
 --- @field display_last_message? neoment.config.DisplayLastMessage How to display the last message in the room list
 
+--- @class neoment.config.DesktopNotifications
+--- @field enabled? boolean Whether desktop notifications are enabled
+--- @field handler? neoment.config.DesktopNotificationHandler Function to handle desktop notifications
+--- @field buffer? neoment.config.DesktopNotificationLevel Notification level for buffer messages. When "none", it'll inherit from the other levels
+--- @field favorites? neoment.config.DesktopNotificationLevel Notification level for favorite rooms
+--- @field people? neoment.config.DesktopNotificationLevel Notification level for people rooms
+--- @field rooms? neoment.config.DesktopNotificationLevel Notification level for people rooms
+
+--- @alias neoment.config.DesktopNotificationHandler fun(title: string, content: string): nil
+--- @alias neoment.config.DesktopNotificationLevel "all"|"mentions"|"none"
+
 --- @class neoment.config.InternalConfig
 --- @field save_session boolean Whether to save and restore sessions
 --- @field icon neoment.config.InternalIcon Icon configuration
 --- @field notifier fun(msg: string, level: vim.log.levels, opts?: table): nil Function to show notifications
---- @field desktop_notifier? fun(title: string, content: string): nil Function to show desktop notifications
+--- @field desktop_notifications neoment.config.InternalDesktopNotifications Configuration for desktop notifications
 --- @field picker neoment.config.InternalPicker Picker configuration
 --- @field rooms neoment.config.InternalRooms
 
@@ -89,6 +100,14 @@
 --- @field display_last_message neoment.config.DisplayLastMessage How to display the last message in the room list
 
 --- @alias neoment.config.DisplayLastMessage "no"|"message"|"sender_message"|"sender_message_inline"
+
+--- @class neoment.config.InternalDesktopNotifications
+--- @field enabled boolean Whether desktop notifications are enabled
+--- @field handler neoment.config.DesktopNotificationHandler Function to handle desktop notifications
+--- @field buffer neoment.config.DesktopNotificationLevel Notification level for buffer messages. When "none", it'll inherit from the other levels
+--- @field favorites neoment.config.DesktopNotificationLevel Notification level for favorite rooms
+--- @field people neoment.config.DesktopNotificationLevel Notification level for people rooms
+--- @field rooms neoment.config.DesktopNotificationLevel Notification level for people rooms
 
 local M = {}
 
@@ -137,9 +156,16 @@ local default = {
 		video = "",
 	},
 	notifier = vim.notify,
-	desktop_notifier = function(title, content)
-		require("neoment.notify").desktop(title, content)
-	end,
+	desktop_notifications = {
+		enabled = true,
+		handler = function(title, content)
+			require("neoment.notify").desktop(title, content)
+		end,
+		buffer = "all",
+		favorites = "all",
+		people = "all",
+		rooms = "mentions",
+	},
 	picker = {
 		rooms = default_room_picker,
 		open_rooms = default_room_picker,

--- a/lua/neoment/matrix/client.lua
+++ b/lua/neoment/matrix/client.lua
@@ -272,21 +272,9 @@ end
 M.add_room_message = function(room_id, message)
 	local room = M.get_room(room_id)
 
+	require("neoment.notify").desktop_message(room, message)
 	if room.is_tracked then
 		room.messages[message.id] = message
-
-		-- Only notify for rooms that are not the current active buffer or when Neovim is unfocused
-		local user_id = require("neoment.matrix").get_user_id()
-		if not message.is_state and message.sender ~= user_id then
-			local current_buf_room_id = vim.b.room_id
-			local has_focus = require("neoment.focus").is_focused()
-			local is_current_room = room_id == current_buf_room_id
-
-			-- Send desktop notification if Neovim is not focused or if it's not the current room
-			if not has_focus or not is_current_room then
-				require("neoment.notify").desktop_message(room, message.sender, message.content)
-			end
-		end
 	elseif not message.is_state then
 		-- If the room is not tracked, only store the last message
 		local last_message = M.get_room_last_message(room_id)

--- a/lua/neoment/notify.lua
+++ b/lua/neoment/notify.lua
@@ -159,6 +159,13 @@ M.desktop_message = function(room, message)
 		return
 	end
 
+	-- Check if this is the initial sync.
+	-- If so, skip notifications to avoid spamming the user.
+	local sync_status = require("neoment.sync").get_status()
+	if sync_status.kind == "syncing" and sync_status.last_sync == nil then
+		return
+	end
+
 	local user_id = require("neoment.matrix").get_user_id()
 	if not user_id or message.is_state or message.sender == user_id then
 		return

--- a/lua/neoment/notify.lua
+++ b/lua/neoment/notify.lua
@@ -141,7 +141,7 @@ end
 
 --- Show a desktop notification for a message
 --- @param room neoment.matrix.client.Room The room where the message was sent
---- @param message neoment.matrix.client.Message The sender of the message
+--- @param message neoment.matrix.client.Message The message to display notification for
 M.desktop_message = function(room, message)
 	local notifications_config = config.get().desktop_notifications
 	if not notifications_config.enabled then

--- a/lua/neoment/notify.lua
+++ b/lua/neoment/notify.lua
@@ -117,6 +117,17 @@ local function message_has_mention(message)
 		return false
 	end
 
+	-- Prefer structured mentions from the Matrix event, if available
+	if type(message.mentions) == "table" then
+		for _, mentioned_id in ipairs(message.mentions) do
+			if mentioned_id == user_id then
+				return true
+			end
+		end
+		return false
+	end
+
+	-- Fallback to string-based detection for compatibility
 	return string.find(message.formatted_content or message.content, user_id, 1, true) ~= nil
 end
 


### PR DESCRIPTION
Add configuration options to control desktop notifications by room type
and message content. Users can now set notification levels (all,
mentions, none) for:
- Buffer rooms (currently open)
- Favorite rooms
- People (direct messages)
- Other rooms

BREAKING CHANGE: The `desktop_notifier` config field has been replaced
with `desktop_notifications` object containing `enabled`, `handler`, and
room-specific notification level settings.

The new structure allows for more flexible notification management,
automatically checking for mentions and respecting user preferences by
room category.