### PR TITLE
feat(matrix): add room aliases support and state events

### DIFF
--- a/after/ftplugin/neoment_compose.lua
+++ b/after/ftplugin/neoment_compose.lua
@@ -24,15 +24,11 @@ set_mapping("i", "<C-s>", "SendInsert", function()
 	require("neoment.room").send_and_close_compose(vim.api.nvim_get_current_buf())
 end, opts)
 
-local function abort()
-	local current_win = vim.api.nvim_get_current_win()
-	vim.api.nvim_set_current_win(vim.b.room_win)
-	vim.api.nvim_win_close(current_win, true)
-end
-
 -- Ctrl+C to cancel
-set_mapping("n", "<C-c>", "Abort", abort, opts)
+set_mapping("n", "<C-c>", "Abort", function()
+	require("neoment.room").close_compose(vim.api.nvim_get_current_buf())
+end, opts)
 set_mapping("i", "<C-c>", "AbortInsert", function()
 	vim.cmd("stopinsert")
-	abort()
+	require("neoment.room").close_compose(vim.api.nvim_get_current_buf())
 end, opts)

--- a/lua/neoment/matrix/client.lua
+++ b/lua/neoment/matrix/client.lua
@@ -295,7 +295,7 @@ end
 
 --- Add an alias to a room.
 --- @param room_id string The ID of the room.
---- @param aliases table<string> The alias to add to the room.
+--- @param aliases table<string> The aliases to set for the room.
 M.set_room_alias = function(room_id, aliases)
 	local room = M.get_room(room_id)
 

--- a/lua/neoment/matrix/client.lua
+++ b/lua/neoment/matrix/client.lua
@@ -16,6 +16,7 @@ M.client = nil
 --- @field id string The ID of the room.
 --- @field is_tracked boolean Indicates if events for this room are being stored. If false, we only store the last message and state events.
 --- @field name string The name of the room.
+--- @field aliases table<string> A table to store aliases of the room.
 --- @field topic string The topic of the room.
 --- @field members table<string, string> A table to store members of the room, mapped as user ID to display name.
 --- @field events neoment.matrix.client.Events A table to store events associated with the room.
@@ -149,9 +150,11 @@ end
 --- @return neoment.matrix.client.Room The created room object
 local function create_new_room(room_id)
 	vim.validate("room_id", room_id, "string")
+	--- @type neoment.matrix.client.Room
 	return {
 		id = room_id,
 		name = room_id,
+		aliases = {},
 		topic = "",
 		events = {},
 		pending_events = {},
@@ -288,6 +291,15 @@ M.add_room_message = function(room_id, message)
 	end
 
 	return message
+end
+
+--- Add an alias to a room.
+--- @param room_id string The ID of the room.
+--- @param aliases table<string> The alias to add to the room.
+M.set_room_alias = function(room_id, aliases)
+	local room = M.get_room(room_id)
+
+	room.aliases = aliases
 end
 
 --- Add a member to a room.

--- a/lua/neoment/matrix/client.lua
+++ b/lua/neoment/matrix/client.lua
@@ -293,10 +293,10 @@ M.add_room_message = function(room_id, message)
 	return message
 end
 
---- Add an alias to a room.
+--- Set the aliases for a room.
 --- @param room_id string The ID of the room.
 --- @param aliases table<string> The aliases to set for the room.
-M.set_room_alias = function(room_id, aliases)
+M.set_room_aliases = function(room_id, aliases)
 	local room = M.get_room(room_id)
 
 	room.aliases = aliases

--- a/lua/neoment/matrix/event.lua
+++ b/lua/neoment/matrix/event.lua
@@ -566,7 +566,7 @@ M.handle = function(room_id, event)
 			:totable()
 		local alias = aliases[1]
 
-		client.set_room_alias(room_id, aliases)
+		client.set_room_aliases(room_id, aliases)
 		local message = canonical_alias_state_event_to_message(event)
 		client.add_room_message(room_id, message)
 		-- We only want to update the name with the alias if it is not already set

--- a/lua/neoment/matrix/event.lua
+++ b/lua/neoment/matrix/event.lua
@@ -216,17 +216,19 @@ end
 --- @param event neoment.matrix.ClientEventWithoutRoomID The state event to convert.
 --- @return neoment.matrix.client.Message The converted message object.
 local function canonical_alias_state_event_to_message(event)
-	local alias = event.content.alias
-	if not alias and event.content.alt_aliases then
-		alias = event.content.alt_aliases[1]
-	end
+	local aliases = vim.iter({ event.content.alias, event.content.alt_aliases or {} })
+		:flatten()
+		:filter(function(a)
+			return a ~= nil
+		end)
+		:join(", ")
 
 	local sender_name = require("neoment.matrix").get_display_name_or_fetch(event.sender)
 	local content
-	if alias then
-		content = string.format("%s set the room alias to %s", sender_name, alias)
+	if #aliases > 0 then
+		content = string.format("%s set the room aliases to %s", sender_name, aliases)
 	else
-		content = string.format("%s removed the room alias", sender_name)
+		content = string.format("%s removed the room aliases", sender_name)
 	end
 
 	--- @type neoment.matrix.client.Message

--- a/lua/neoment/matrix/event.lua
+++ b/lua/neoment/matrix/event.lua
@@ -562,18 +562,16 @@ M.handle = function(room_id, event)
 				return a ~= nil
 			end)
 			:totable()
-		-- We only want to update the name with the alias if it is not already set
 		local alias = aliases[1]
 
 		client.set_room_alias(room_id, aliases)
 		local message = canonical_alias_state_event_to_message(event)
 		client.add_room_message(room_id, message)
-		if alias then
-			if room.name == room.id then
-				client.get_room(room_id).name = event.content.alias
-				return true
-			end
+		-- We only want to update the name with the alias if it is not already set
+		if alias and room.name == room.id then
+			client.get_room(room_id).name = alias
 		end
+		return true
 	elseif event.type == "m.room.topic" then
 		client.get_room(room_id).topic = event.content.topic
 		return true
@@ -668,13 +666,12 @@ M.handle_multiple = function(room_id, events)
 	table.sort(events, function(a, b)
 		return (a.origin_server_ts or 0) < (b.origin_server_ts or 0)
 	end)
-	-- for _, event in ipairs(events) do
 	vim.iter(events):each(function(event)
 		if M.handle(room_id, event) then
 			handled = true
 		end
 
-		if not event or not event.event_id then
+		if not event.event_id then
 			-- Skip events without an ID
 			return
 		end

--- a/lua/neoment/matrix/event.lua
+++ b/lua/neoment/matrix/event.lua
@@ -212,10 +212,47 @@ local function event_to_message(event, replying_to)
 	}
 end
 
---- Convert a Matrix state event to a message.
+--- Convert a Matrix `m.room.canonical_alias` state event to a message.
+--- @param event neoment.matrix.ClientEventWithoutRoomID The state event to convert.
+--- @return neoment.matrix.client.Message The converted message object.
+local function canonical_alias_state_event_to_message(event)
+	local alias = event.content.alias
+	if not alias and event.content.alt_aliases then
+		alias = event.content.alt_aliases[1]
+	end
+
+	local sender_name = require("neoment.matrix").get_display_name_or_fetch(event.sender)
+	local content
+	if alias then
+		content = string.format("%s set the room alias to %s", sender_name, alias)
+	else
+		content = string.format("%s removed the room alias", sender_name)
+	end
+
+	--- @type neoment.matrix.client.Message
+	return {
+		id = event.event_id,
+		sender = event.sender,
+		content = content,
+		formatted_content = nil,
+		timestamp = event.origin_server_ts,
+		age = event.unsigned and event.unsigned.age or nil,
+		was_edited = false,
+		was_redacted = false,
+		mentions = {},
+		replying_to = nil,
+		reactions = {},
+		attachment = nil,
+		is_state = true,
+		thread_root_id = nil,
+		thread_replies_count = nil,
+	}
+end
+
+--- Convert a Matrix `m.room.member` state event to a message.
 --- @param event neoment.matrix.ClientEventWithoutRoomID The state event to convert.
 --- @return neoment.matrix.client.Message? The converted message object.
-local function state_event_to_message(event)
+local function member_state_event_to_message(event)
 	local membership = event.content.membership
 	local prev_content = event.unsigned and event.unsigned.prev_content or nil
 	local sender_name = require("neoment.matrix").get_display_name_or_fetch(event.sender)
@@ -290,7 +327,7 @@ local function state_event_to_message(event)
 
 	local display_name = require("neoment.matrix").get_display_name(event.state_key)
 
-	local content = string.format("%s %s", display_name, message_action)
+	local content = string.format("Membership: %s %s", display_name, message_action)
 
 	--- @type neoment.matrix.client.Message
 	return {
@@ -519,17 +556,23 @@ M.handle = function(room_id, event)
 		return true
 	elseif event.type == "m.room.canonical_alias" then
 		local room = client.get_room(room_id)
+		local aliases = vim.iter({ event.content.alias, event.content.alt_aliases or {} })
+			:flatten()
+			:filter(function(a)
+				return a ~= nil
+			end)
+			:totable()
 		-- We only want to update the name with the alias if it is not already set
-		if room.name == room.id then
-			local alias = event.content.alias
-			if not alias and event.content.alt_aliases then
-				alias = event.content.alt_aliases[1]
-			end
+		local alias = aliases[1]
 
-			if alias then
+		client.set_room_alias(room_id, aliases)
+		local message = canonical_alias_state_event_to_message(event)
+		client.add_room_message(room_id, message)
+		if alias then
+			if room.name == room.id then
 				client.get_room(room_id).name = event.content.alias
+				return true
 			end
-			return true
 		end
 	elseif event.type == "m.room.topic" then
 		client.get_room(room_id).topic = event.content.topic
@@ -541,7 +584,7 @@ M.handle = function(room_id, event)
 			client.remove_room_member(room_id, event.state_key)
 		end
 
-		local message = state_event_to_message(event)
+		local message = member_state_event_to_message(event)
 		if message then
 			client.add_room_message(room_id, message)
 		end
@@ -621,14 +664,19 @@ end
 --- @return boolean True if any event was handled, false otherwise
 M.handle_multiple = function(room_id, events)
 	local handled = false
-	for _, event in ipairs(events) do
+	-- Sort the events by origin_server_ts to ensure they are processed in order
+	table.sort(events, function(a, b)
+		return (a.origin_server_ts or 0) < (b.origin_server_ts or 0)
+	end)
+	-- for _, event in ipairs(events) do
+	vim.iter(events):each(function(event)
 		if M.handle(room_id, event) then
 			handled = true
 		end
 
 		if not event or not event.event_id then
 			-- Skip events without an ID
-			goto continue
+			return
 		end
 
 		-- Handle pending actions
@@ -637,8 +685,7 @@ M.handle_multiple = function(room_id, events)
 			M.handle_multiple(room_id, vim.tbl_values(pending_events))
 			client.get_room(room_id).pending_events[event.event_id] = nil
 		end
-		::continue::
-	end
+	end)
 
 	return handled
 end

--- a/lua/neoment/matrix/init.lua
+++ b/lua/neoment/matrix/init.lua
@@ -981,7 +981,16 @@ end
 M.get_room_aliases = function(room_id)
 	vim.validate("room_id", room_id, "string")
 
-	return client.get_room(room_id).aliases or {}
+	-- If it's an invited room, return empty table
+	if not M.has_room(room_id) then
+		return {}
+	end
+
+	local room = client.get_room(room_id)
+	if not room then
+		return {}
+	end
+	return room.aliases or {}
 end
 
 --- Get the other members of a room.

--- a/lua/neoment/matrix/init.lua
+++ b/lua/neoment/matrix/init.lua
@@ -975,6 +975,15 @@ M.get_room_members = function(room_id)
 	end, client.get_room(room_id).members)
 end
 
+--- Get the aliases of a room.
+--- @param room_id string The ID of the room.
+--- @return table<string> The aliases of the room.
+M.get_room_aliases = function(room_id)
+	vim.validate("room_id", room_id, "string")
+
+	return client.get_room(room_id).aliases or {}
+end
+
 --- Get the other members of a room.
 --- @param room_id string The ID of the room.
 --- @return table<string, string> The other members of the room. The keys are user IDs and the values are display names.

--- a/lua/neoment/room.lua
+++ b/lua/neoment/room.lua
@@ -341,11 +341,6 @@ local function messages_to_lines(buffer_id)
 		-- Check if the content exists
 		local content = message.content or ""
 
-		-- Handle membership events specially
-		if message.is_state then
-			content = "Membership: " .. content
-		end
-
 		-- If there's a formatted content, convert it to markdown
 		if message.formatted_content then
 			content = markdown.from_html(message.formatted_content)
@@ -573,9 +568,9 @@ local function apply_highlights(buffer_id, room_id, lines)
 			end
 
 			if message.is_header then
-				-- Special handling for membership events
+				-- Special handling for state events
 				if message.is_state then
-					-- Apply Comment highlight for membership events and no header
+					-- Apply Comment highlight for state events and no header
 					api.nvim_buf_set_extmark(buffer_id, EXTMARK_NAMESPACE, index - 1, 0, {
 						virt_text = {
 							{ string.rep(" ", 28) .. " " .. config_icon.vertical_bar .. " ", SEPARATOR_HIGHLIGHT },

--- a/lua/neoment/room_info.lua
+++ b/lua/neoment/room_info.lua
@@ -4,6 +4,13 @@ local constants = require("neoment.constants")
 local util = require("neoment.util")
 local matrix = require("neoment.matrix")
 
+--- Converts a Matrix path (room ID or alias) to a matrix.to link.
+--- @param path string The Matrix path (room ID or alias).
+--- @return string The matrix.to link.
+local function to_matrix_link(path)
+	return "https://matrix.to/#/" .. vim.uri_encode(path)
+end
+
 --- Opens the room info window for the given room ID.
 --- @param room_id string The ID of the room to open info for.
 --- @return number The buffer number of the room info window.
@@ -68,8 +75,20 @@ M.update_buffer = function(buffer_id)
 
 	-- Room ID
 	table.insert(lines, "**Room ID:** " .. room_id)
-	local room_link = "https://matrix.to/#/" .. vim.uri_encode(room_id)
-	table.insert(lines, "**Room link:** " .. room_link)
+	-- Aliases
+	local aliases = matrix.get_room_aliases(room_id)
+	if #aliases > 0 then
+		table.insert(lines, "**Aliases:**")
+		vim.iter(aliases):each(function(line)
+			table.insert(lines, " - " .. line)
+		end)
+	end
+	table.insert(lines, "")
+	table.insert(lines, "**Room links:**")
+	table.insert(lines, " - " .. to_matrix_link(room_id))
+	vim.iter(aliases):each(function(alias)
+		table.insert(lines, " - " .. to_matrix_link(alias))
+	end)
 	table.insert(lines, "")
 
 	-- Topic/Description

--- a/lua/neoment/room_info.lua
+++ b/lua/neoment/room_info.lua
@@ -79,8 +79,8 @@ M.update_buffer = function(buffer_id)
 	local aliases = matrix.get_room_aliases(room_id)
 	if #aliases > 0 then
 		table.insert(lines, "**Aliases:**")
-		vim.iter(aliases):each(function(line)
-			table.insert(lines, " - " .. line)
+		vim.iter(aliases):each(function(alias)
+			table.insert(lines, " - " .. alias)
 		end)
 	end
 	table.insert(lines, "")

--- a/lua/neoment/storage.lua
+++ b/lua/neoment/storage.lua
@@ -93,6 +93,7 @@ local function get_stripped_room(room)
 	return {
 		id = room.id,
 		name = room.name,
+		aliases = room.aliases,
 		topic = room.topic,
 		-- No need to store the event history
 		events = {},


### PR DESCRIPTION
- Add aliases field to Room type and client initialization
- Implement set_room_alias and get_room_aliases functions
- Convert canonical_alias events to human-readable messages
- Display alias changes in room timeline as state events
- Show all room aliases in room info window with matrix.to links
- Refactor member_state_event_to_message for clarity
- Store room aliases in persistent storage
- Sort events by timestamp before processing to maintain order
- Replace goto with iterator pattern in event handling